### PR TITLE
Some Extra Tweaks (Profile, Permissions, etc.)

### DIFF
--- a/src/components/color.css
+++ b/src/components/color.css
@@ -333,7 +333,8 @@
 	background-color: var(--brand-experiment-30a);
 }
 
-.reaction-3vwAF2 .reactionInner-YJjOtT {
+.reaction-3vwAF2 .reactionInner-YJjOtT,
+.reaction-3vwAF2.reactionInner-YJjOtT {
 	padding: 0 0.375rem;
 }
 .reaction-3vwAF2.reactionMe-1PwQAc .reactionCount-26U4As,

--- a/src/components/other.css
+++ b/src/components/other.css
@@ -116,6 +116,21 @@
 .passthrough--fbdFR.selected-3jieYB {
 	background-color: #787e8a;
 }
+.passthrough--fbdFR svg {
+	display: none;
+}
+.passthrough--fbdFR:not(.selected-3jieYB)::after {
+	content: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'><rect width='1.5' height='16' x='7.5' y='0' fill='rgb(120, 126, 138)' class='ci-primary'/></svg>");
+    height: 16px;
+    width: 16px;
+    rotate: 45deg;
+}
+.passthrough--fbdFR.selected-3jieYB::after {
+	content: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'><rect width='1.5' height='16' x='7.5' y='0' fill='rgb(255, 255, 255)' class='ci-primary'/></svg>");
+    height: 16px;
+    width: 16px;
+    rotate: 45deg;
+}
 .item-4m-12I {
 	cursor: pointer;
 }
@@ -1033,4 +1048,8 @@ taken from dtm-17 (im a lazy fuck :p)*/
 }
 #app-mount .playIcon-1cttj4:hover {
 	color: var(--interactive-active);
+}
+/* Green Speaking Border in Maximized Voice Chats */
+.border-2Vy6FN.speaking-7QZEkv {
+	box-shadow: inset 0 0 0 2px var(--green-360);
 }

--- a/src/components/profile.css
+++ b/src/components/profile.css
@@ -185,6 +185,7 @@
 }
 
 .userProfileOuterThemed-2BgJCM,
+.userProfileInnerThemedPremiumWithoutBanner-lZ9inp,
 .userProfileInnerThemedWithBanner-25XGmz {
 	background: var(--bg-overlay-1, var(--background-tertiary));
 	box-shadow: none;
@@ -222,6 +223,7 @@ div.clickable-GKg4Qy.avatarWrapperNormal-ahVUaC.avatarWrapper-eenWra.avatarPosit
 /* do the same but for profiles with premium and no colours or something idfk */
 div.clickable-GKg4Qy.avatarWrapperNormal-ahVUaC.avatarWrapper-eenWra.avatarPositionPremiumNoBanner-nWzERs > div > div > svg > circle,
 div.clickable-GKg4Qy.avatarWrapperNormal-ahVUaC.avatarWrapper-eenWra.avatarPositionPremiumNoBanner-nWzERs > div > div > svg > rect:nth-child(2),
+div.avatarHoverTarget-1zzfRL > .wrapper-3Un6-K > svg > circle,
 /* and the same for full profile dialogs */
 div.topSection-13QKHs > header > div > div:nth-child(1) > div > svg > circle,
 div.topSection-13QKHs > header > div > div:nth-child(1) > div > svg > rect:nth-child(2) {


### PR DESCRIPTION
this is very specific but profiles that have custom colours but no banner aren't coloured correctly, so I fixed that.
## Before:
![image](https://user-images.githubusercontent.com/83364207/233162742-a86cddc7-aad5-4870-9eb1-4f6e58395f4a.png)
## After:
![image](https://user-images.githubusercontent.com/83364207/233162762-7d3ca4e4-b063-43e4-a40e-fb5946d11c6b.png)

i also reverted the "passthrough" icon in the permissions menu to the one it used to be
## Before:
![image](https://user-images.githubusercontent.com/83364207/233162935-8a550d05-c667-425a-ab9c-7e3d23ab0906.png)
## After:
![image](https://user-images.githubusercontent.com/83364207/233162914-d6b2396f-dd2d-4c48-bbe9-11b6b9a6f517.png)

and this is also very specific but when reactions are out of view, they retain their normal padding, but get correct when they're in view, which causes a lot of annoying jumping when trying to scroll through messages with lots of reactions. (the jumping still occurs but is not as intense)
## Before:
![image](https://user-images.githubusercontent.com/83364207/233163430-78359080-9078-46d5-a055-d1d747da36ce.png)
## After:
![image](https://user-images.githubusercontent.com/83364207/233163447-a4d14879-fbf2-4867-8e33-77dd9f0ddadb.png)

and some extra few tweaks here and there