### PR TITLE
Update old emojis CSS selectors

### DIFF
--- a/src/components/oldEmojis.css
+++ b/src/components/oldEmojis.css
@@ -1,4 +1,4 @@
 /*plead 🥺*/
-[src*="f3f159b921f71864327c.svg"]{content: url("https://milbits.github.io/oldcord/src/assets/oldPlead.svg");}
+[src*="98fca45b1f4310224767.svg"]{content: url("https://milbits.github.io/oldcord/src/assets/oldPlead.svg");}
 /*holding back 🥹*/
-[src*="f2e5d8cf525a4550e1b1.svg"]{content: url("https://milbits.github.io/oldcord/src/assets/oldHoldingBack.svg");}
+[src*="6c4e5d9cb23057ca347f.svg"]{content: url("https://milbits.github.io/oldcord/src/assets/oldHoldingBack.svg");}


### PR DESCRIPTION
Discord keeps changing the class names and src tags for all of their stuff like every month now. Can a mf not have their crunchy old Discord in peace??