### PR TITLE
fix: windows 10 window decoration cut off

### DIFF
--- a/src/components/redesign.css
+++ b/src/components/redesign.css
@@ -975,7 +975,7 @@
 		gap: unset;
 		justify-content: center;
 		bottom: 35px;
-		left: 26px;
+		left: -12px;
 		z-index: 3001;
 		-webkit-app-region: no-drag !important;
 		.winButton_c38106 {


### PR DESCRIPTION
Before current changes:
![before](https://github.com/user-attachments/assets/beb65c35-cdb9-4ec0-b370-7bfcf988d72e)

After current changes:
![after](https://github.com/user-attachments/assets/2ac2c9d6-36c5-4b95-a73f-c8f3bc119bd3)