### PR TITLE
fix: blank space when fullscreen watching screenshare

### DIFF
--- a/src/components/redesign.css
+++ b/src/components/redesign.css
@@ -1200,6 +1200,13 @@
 	display: none;
 }
 
+/* hides left sidebar when fullscreen mode */
+.base_c48ade[data-fullscreen="true"] {
+    .sidebar_c48ade{
+        display: none;
+    }
+}
+
 .spriteContainer__04eed {
 	--custom-emoji-sprite-size: 24px !important;
 }


### PR DESCRIPTION
When going fullscreen and watching someone's screenshare, a blank space on the left side is noticeable.
https://github.com/user-attachments/assets/d47b7092-ed98-43ad-8da8-2f64479e4ca9


After checking the devtools I've concluded this blank space occurs because the left sidebar where the server list and the current server's channels are doesn't get hidden and so it keep occupying space when it shouldn't.

The solution was just adding a display none for the sidebar when fullscreen.
As far as I've tested nothing else got broken, but some further checking might be needed just to be sure. 