### PR TITLE
Make inline code block in embed more like old Discord

### DIFF
--- a/src/components/redesign.css
+++ b/src/components/redesign.css
@@ -689,6 +689,9 @@
 	.markup__75297 code.inline {
 	    font-family: var(--font-code) !important;
 	}
+	.embedFull__623de code.inline {
+		background: var(--background-tertiary) !important;
+	}
 
 	/* discord logo */
 	.childWrapper__6e9f8 svg {


### PR DESCRIPTION
I made a more minimalist private version of this theme, and found out GitHub embed felt odd even with this theme fully applied.
<details> 
  <summary>Attached is a screenshot of the change</summary>

![image](https://github.com/user-attachments/assets/2854c20e-4210-4083-8fe0-480fa6287aca)

</details>
