### PR TITLE
Make changes to offset only if they have an avatar decoration

### DIFF
--- a/src/components/showEffects.css
+++ b/src/components/showEffects.css
@@ -15,7 +15,7 @@
 
 /*move that weird circle to the middle*/
 .mask__68edb mask circle{
-    transform: translateX(68.5px);
+    transform: translateX(69.5px);
 }
 :has(.custom-theme-background) .mask__68edb mask circle{
     transform: translateX(73px) translateY(5px);
@@ -32,10 +32,6 @@
     max-width: 250px;
 }
 
-.avatar__75742{
-    position: absolute !important;
-    top: 62px !important
-}
 /*fix for reaction stuff*/
 .avatar__75742:has(.wrapper_f7ecac){
     position: absolute !important;
@@ -52,8 +48,8 @@
     top: 157px !important;
 }
 .accountProfilePopoutWrapper__37e49 .container_ab8609.biteSize_ab8609 {
-	top: -103px !important;
-	left: -105px
+    top: -103px !important;
+    left: -105px
 }
 
 /*add colors back (but without that annoying border ew)*/
@@ -73,20 +69,20 @@
 
 /* banners behind headers */
 .fullSize_c0bea0.inner_c0bea0 .mask__68edb {
-	position: absolute;
-	z-index: 0;
-	opacity: 25%;
+    position: absolute;
+    z-index: 0;
+    opacity: 25%;
 }
 .fullSize_c0bea0.inner_c0bea0 .headerInner__24502 {
     background: transparent !important;
 }
 
 .fullSize_c0bea0.inner_c0bea0:has(.mask__68edb) .body__24502 {
-	& .fullSizeOverlayBackground_c69a7b {
-		z-index: 2;
-	}
+    & .fullSizeOverlayBackground_c69a7b {
+        z-index: 2;
+    }
     & .container__63ed3 {
-	    background: transparent !important;
+        background: transparent !important;
     }
 }
 
@@ -95,5 +91,11 @@
 .outer_c0bea0.fullSize_c0bea0,
 .custom-profile-theme {
     --theme-base-color-amount: 50% !important; 
-	--theme-text-color-amount: 25% !important;
+    --theme-text-color-amount: 25% !important;
+}
+
+/* apply ONLY if they have an avatar deco*/
+div:has(.avatarDecoration__44b0c) .avatar__75742 {
+    position: absolute !important;
+    top: 30px !important;
 }


### PR DESCRIPTION
Make changes to offset only if they have an avatar decoration as to not break profile view.
Obviously if I broke something, or you don't like something, you have every right to decline my PR. Thank you for all the work you've done on this theme! <3

Before change, Profile without effects.
![image](https://github.com/user-attachments/assets/3f796963-fb34-495d-8874-7ccd206df61a)

Before change, Profile with effects.
![image](https://github.com/user-attachments/assets/31972ce2-30f4-4c1f-9f92-8ca766cac419)


After change, Profile without effects.
![image](https://github.com/user-attachments/assets/5db68f0f-adc5-4a89-bc10-cd2ffd94d217)

After change, Profile with effects.
![image](https://github.com/user-attachments/assets/f120020c-8522-4820-9378-166afff625cb)
