### PR TITLE
refactor(redesign): actually mimic the macOS titlebar design

### DIFF
--- a/src/components/redesign.css
+++ b/src/components/redesign.css
@@ -49,9 +49,9 @@
 		"titleBar titleBar titleBar"
 		"notice notice notice"
 		"guildsList channelsList page";
-	grid-template-rows: [top] 0px [titlebarEnd] min-content [page] 35px [end] !important;
-	.sidebarListRounded_c48ade {
-		border-top-left-radius: 8px !important;
+	grid-template-rows: [top] 0px [titlebarEnd] min-content [page] 0px [end] !important;
+	.sidebar_c48ade > .guilds_c48ade {
+		margin-top: 32px;
 	}
 	.bar_c38106 .trailing_c38106 {
 		top: 67px;
@@ -66,6 +66,9 @@
 	&:has(.notice__6e2b9, .bd-notice) :is(.sidebarList_c48ade, .page_c48ade) {
 		margin-top: 27px !important;	
 	}
+}
+.platform-osx .systemBar_c38106 {
+	background: none;
 }
 html.platform-win .sidebarListRounded_c48ade {
 	border-top-left-radius: 8px !important;


### PR DESCRIPTION
Removed the space reserved for the titlebar and added top padding for the guild list

<img width="1912" alt="" src="https://github.com/user-attachments/assets/08ffc3e7-d875-4db6-9389-37c18cdda3cb" />
