### PR TITLE
Add style for pending server join folder

### DIFF
--- a/src/components/redesign.css
+++ b/src/components/redesign.css
@@ -2682,6 +2682,19 @@ html .bar_c38106 {
 	display: none;
 }
 
+.tutorialContainer__1f388 ~ .container__93fc9 {
+    margin-top: 8px;
+    margin-bottom: 4px;
+}
+
+.tutorialContainer__1f388 ~ .container__93fc9 .folderGroup__48112:not(.isExpanded__48112) .folderIconWrapper__48112 {
+    padding: 0;
+}
+
+.folderGroup__48112:not(.isExpanded__48112) .pendingFolderButtonIcon__93fc9 {
+    --guildbar-avatar-size: 48px;
+}
+
 /* fix unread dm gap */
 .stack_dbd263#guild-list-unread-dms {
 	gap: 16px !important;


### PR DESCRIPTION
please excuse the rough implementation

<img width="83" height="161" alt="closed folder" src="https://github.com/user-attachments/assets/59716a0b-6721-44fc-8497-7c150630d7b6" />
<img width="83" height="214" alt="expanded folder" src="https://github.com/user-attachments/assets/ffb272be-dad2-4807-bca0-85d048f572fe" />

no before (I successfully joined before I could take one)