### PR TITLE
Add `primary-630` and `primary-660` variable fixes for broken light theme

### DIFF
--- a/src/components/vars.css
+++ b/src/components/vars.css
@@ -141,6 +141,8 @@ html:not(.custom-theme-background) .theme-light {
 	--background-secondary-alt: hsl(var(--oldcord-tint) var(--oldcord-tint-intensity) 83%);
 	--text-default: hsl(0deg 0% 13.33%);
 	--chat-background-default: hsl(var(--oldcord-tint) var(--oldcord-tint-intensity) 90.94%);
+	--primary-630: var(--background-secondary);
+    --primary-660: var(--background-tertiary);
 	--primary-700: var(--background-tertiary);
 
 	--background-modifier-accent: #06060714;


### PR DESCRIPTION
<img width="268" height="66" alt="Screenshot 2026-02-26 at 17 07 57" src="https://github.com/user-attachments/assets/ec70158c-e7ba-450f-aa5a-78c73288044b" />
<img width="727" height="407" alt="Screenshot 2026-02-26 at 17 09 09" src="https://github.com/user-attachments/assets/1f3e537e-67df-405b-bc1b-6c62adcc249f" />
<img width="621" height="327" alt="Screenshot 2026-02-26 at 17 10 10" src="https://github.com/user-attachments/assets/6e4407c1-f859-4582-af22-3ec123e9ac75" />
