### PR TITLE
fix: SVG dimensions for avatar decorations, guild banner img size

### DIFF
--- a/src/components/redesign.css
+++ b/src/components/redesign.css
@@ -2148,13 +2148,6 @@ html.visual-refresh {
 		}
 	}
 
-	/* server banner images */
-	.bannerImage_f37cb1,
-	.bannerImg_f37cb1 {
-		width: 240px;
-		aspect-ratio: unset;
-	}
-
 	/* tooltips */
 	.dialogWrapper_b1f768,
 	.tooltipPrimary_c36707,

--- a/src/components/redesign.css
+++ b/src/components/redesign.css
@@ -1096,6 +1096,10 @@ html.visual-refresh {
 				width: 40px;
 				height: 40px;
 			}
+			svg.avatarDecorationContainer__44b0c {
+				width: 46.4px;
+				height: 38.4px;
+			}
 		}
 	}
 	.toolbar__9293f .clickable__81391 {


### PR DESCRIPTION
the SVG sizes isn't changing on my part. Might be worth removing the block altogether?

(notice the right ear being hidden)

<img width="154" height="54" alt="" src="https://github.com/user-attachments/assets/3b8bef33-9a3f-4cec-b9d7-075b527717ec" />
<img width="154" height="54" alt="" src="https://github.com/user-attachments/assets/a7f5408a-d1da-47b6-9a45-5d492eda7ee4" />


