### PR TITLE
fix: right-aligned search bar

### DIFF
--- a/src/components/redesign.css
+++ b/src/components/redesign.css
@@ -677,6 +677,7 @@ html.visual-refresh {
 		width: 144px;
 		border-radius: 4px;
 		border: none;
+		justify-self: end;
 		.DraftEditor-root {
 			padding: 2px 0;
 			line-height: 20px;
@@ -685,6 +686,7 @@ html.visual-refresh {
 			fill: var(--text-muted);
 		}
 	}
+	.search_c322aa:is(.open_c322aa),
 	.search_c322aa:is(.open_c322aa) .searchBar_c322aa {
 		width: 240px;
 	}


### PR DESCRIPTION
Fix an issue where search bar expands to the right (due to `width: 144px` on `.search_c322aa` itself). Also align it so that the expanding animation feels more natural and doesn't move the search icon.